### PR TITLE
Performance improvement in converting datetime

### DIFF
--- a/bot_jobs/build_province_and_district_cases.py
+++ b/bot_jobs/build_province_and_district_cases.py
@@ -19,7 +19,7 @@ df = pd.read_csv(dataset_path, encoding="utf-8")
 df = df.drop(["No.", "Notified date", "nationality", "province_of_isolation",
               "sex", "age", "risk", "Unit"], axis=1)
 # Convert day to datetime object
-df["announce_date"] = df["announce_date"].map(lambda date: datetime.datetime.strptime(date, "%d/%m/%Y"))
+df["announce_date"] = pd.to_datetime(df["announce_date"], format="%d/%m/%Y")
 
 # Filter from start date
 end = df.tail(1)["announce_date"].iloc[0]
@@ -27,7 +27,7 @@ start = end - datetime.timedelta(days=14)
 start = start.replace(hour=0, minute=0, second=0, microsecond=0)
 df = df[(df['announce_date'] > start) & (df['announce_date'] <= end)]
 # Convert datetime object to ISO string 
-df["announce_date"] = df["announce_date"].map(lambda dto: dto.isoformat())
+df["announce_date"] = df["announce_date"].apply(lambda dto: dto.isoformat())
 
 # Change อำเภอ เมือง -> อำเภอ เมือง + จังหวัด
 mueng_df = df[df.district_of_onset == "เมือง"]
@@ -65,7 +65,10 @@ df_filtered_by_province = df_no_district[df_no_district.province_of_onset.isin(p
 df_invalid_province = df_no_district[~df_no_district.province_of_onset.isin(province_names)]
 df_invalid_province = df_invalid_province.fillna(0)
 with pd.option_context('display.max_rows', None, 'display.max_columns', None):
-    print(df_invalid_province[df_invalid_province.province_of_onset != 0])
+    df_wrong_name = df_invalid_province[df_invalid_province.province_of_onset != 0]
+    print(df_wrong_name)
+    print(df_wrong_name.info())
+
 
 # Count values by provinces by date
 province_cases_each_day = pd.crosstab(df_filtered_by_province.announce_date,

--- a/bot_jobs/get_covid_test_dataset.py
+++ b/bot_jobs/get_covid_test_dataset.py
@@ -5,14 +5,14 @@ import datetime
 url = "https://data.go.th/dataset/9f6d900f-f648-451f-8df4-89c676fce1c4/resource/0092046c-db85-4608-b519-ce8af099315e/download/testing_data.xlsx"
 
 # Download and read excel as df
-df = pd.read_excel(url)
+df = pd.read_excel(url, engine="openpyxl")
 
 # Select a specific column
 df = df[['Date','Pos','Total']]
 # Remove cannot specify date and time
 df = df.drop(0).reset_index(drop=True) 
 # Map datatime to YYYY-MM-DD
-df["Date"] = df["Date"].map(lambda dto: datetime.datetime.strftime(dto,"%Y-%m-%d"))
+df["Date"] = df["Date"].apply(lambda dto: datetime.datetime.strftime(dto,"%Y-%m-%d"))
 df = df[(df['Date'] >= "2021-01-01")]
 df = df.rename(columns={"Date": "date", "Pos": "positive", "Total": "tests"})
 

--- a/bot_jobs/get_provincial_dataset.py
+++ b/bot_jobs/get_provincial_dataset.py
@@ -15,12 +15,17 @@ if (req.status_code == 200) :
     # Dataset typo corrections
     start = time.time()
     text = req.text.replace("ุุ", "ุ") 
+    text = text.replace("่่", "่")
+    text = text.replace("้้","้")
+    text = text.replace("็็","็")
+    text = text.replace("ิิ", "ิ")
     text = text.replace("เเ", "แ") 
     text = text.replace("อ.", "")
     text = text.replace("จ.", "")
     text = text.replace("กทม", "กรุงเทพมหานคร")
     text = text.replace("กำแพงเพฃร", "กำแพงเพชร")
     text = text.replace("ลพบรี", "ลพบุรี")
+    text = text.replace("พระนครศรีอยุทธยา", "พระนครศรีอยุธยา")
     with open(path, "w+", encoding="utf-8") as fout :
         fout.write(text)
     print("Provincial dataset written to", path+",", "Took:", time.time()-start, "seconds")

--- a/bot_jobs/util.py
+++ b/bot_jobs/util.py
@@ -35,9 +35,8 @@ def get_start_end(data):
 
 def get_provinces(data, start):
     data_ymd = data.copy()
-    data_ymd["announce_date"] = data_ymd["announce_date"].map(
-        lambda date: datetime.datetime.strptime(date.strip(), "%d/%m/%Y"))
-    data_filtered = data_ymd[data_ymd["announce_date"] >= start]
+    data_ymd["announce_date"] = pd.to_datetime(data_ymd["announce_date"], format="%d/%m/%Y")
+    data_filtered = data_ymd[data_ymd["announce_date"] > start]
     return pd.crosstab(data_filtered.announce_date, data_filtered.province_of_onset).to_dict()
 
 


### PR DESCRIPTION
- Use pandas method to convert directly. (rather than using map)
- Build provinces and district case runtime reduced by half.
- More typo correction. :disappointed:
- More verbose typo with typo count shown.