### PR TITLE
Fix performance of graphs

### DIFF
--- a/components/deathsCurve.tsx
+++ b/components/deathsCurve.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useMemo, useCallback } from 'react';
 import { extent, max, bisector, min } from 'd3-array'
 import _ from 'lodash'
 import moment from 'moment'
@@ -17,25 +17,31 @@ function DeathsCurve(props) {
     var timeSeries = props.national_stats
     const width = props.width
     const height = props.height
-    const x = d => new Date(d['date'])
-    const y = d => d['new_deaths']
-    const { moving_aves: avgs, timeSeries: calculatedTimeSeries } = movingAvg(timeSeries, 'new_deaths', 'rate')
-    avgs.map((avg, i) => {
-        calculatedTimeSeries[i]['movingAvg'] = avg
-    })
-    const xScale = scaleBand({
+    const x = useCallback(d => new Date(d['date']), [])
+    const y = useCallback(d => d['new_deaths'], [])
+    const calculatedTimeSeries = useMemo(
+      () => {
+        const { moving_aves: avgs, timeSeries: innerTimeSeries } = movingAvg([...timeSeries], 'new_deaths', 'rate')
+        avgs.forEach((avg, i) => {
+          innerTimeSeries[i]['movingAvg'] = avg
+        })
+        return innerTimeSeries
+      },
+      [timeSeries]
+    )
+    const xScale = useMemo(() => scaleBand({
         range: [0, width],
         domain: calculatedTimeSeries.map(x),
         padding: 0.07
-    })
-    const dateScale = scaleTime({
+    }), [width, calculatedTimeSeries, x])
+    const dateScale = useMemo(() => scaleTime({
         range: [0, width],
         domain: extent(calculatedTimeSeries, x),
-    })
-    const yScale = scaleLinear({
+    }), [width, calculatedTimeSeries, x])
+    const yScale = useMemo(() => scaleLinear({
         range: [height, 50],
         domain: [0, max(calculatedTimeSeries, y)],
-    })
+    }), [height, calculatedTimeSeries, y])
     const {
         showTooltip,
         hideTooltip,
@@ -61,7 +67,7 @@ function DeathsCurve(props) {
                         เสียชีวิต
                     </Text>
                     <Group>
-                        {calculatedTimeSeries.map((d, i) => {
+                        {useMemo(() => calculatedTimeSeries.map((d, i) => {
                             const barHeight = height - yScale(y(d))
                             return (
                                 <Bar
@@ -74,7 +80,7 @@ function DeathsCurve(props) {
                                 />
 
                             );
-                        })}
+                        }), [calculatedTimeSeries, height, yScale, y, xScale, x])}
                     </Group>
                     <LinePath
                         curve={curveBasis}
@@ -146,9 +152,9 @@ function DeathsCurve(props) {
 
 const Container = (props) => (
     <ParentSize>
-        {({ width, height }) => (
+        {useCallback(({ width, height }) => (
             <DeathsCurve national_stats={props.national_stats} width={width} height={width > 250 ? 200 : 150} />
-        )}
+        ), [])}
     </ParentSize>
 )
 

--- a/components/infectionCurve.js
+++ b/components/infectionCurve.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useCallback, useMemo } from 'react';
 import { extent, max, bisector, min } from 'd3-array'
 import _ from 'lodash'
 import moment from 'moment'
@@ -15,30 +15,36 @@ import { Label, Connector, Annotation } from '@visx/annotation'
 import { movingAvg } from './vaccine/util'
 
 function NationalCurve(props) {
-    var timeSeries = props.national_stats
+    console.log('rerendered')
+    const timeSeries = props.national_stats
     const width = props.width
     const height = props.height
-    const x = d => new Date(d['date'])
-    const y = d => d['new_cases']
-    const { moving_aves: avgs, timeSeries: calculatedTimeSeries } = movingAvg(timeSeries, 'new_cases', 'rate')
-    avgs.map((avg, i) => {
-        calculatedTimeSeries[i]['movingAvg'] = avg
-    })
-
-    const xScale = scaleBand({
+    const x = useCallback(d => new Date(d['date']), [])
+    const y = useCallback(d => d['new_cases'], [])
+    const calculatedTimeSeries = useMemo(
+      () => {
+        const { moving_aves: avgs, timeSeries: innerTimeSeries } = movingAvg([...timeSeries], 'new_cases', 'rate')
+        avgs.forEach((avg, i) => {
+          innerTimeSeries[i]['movingAvg'] = avg
+        })
+        return innerTimeSeries
+      },
+      [timeSeries]
+    )
+    const xScale = useCallback(scaleBand({
         range: [0, width],
         domain: calculatedTimeSeries.map(x),
         padding: 0.07
-    })
-    const dateScale = scaleTime({
+    }), [width, calculatedTimeSeries, x])
+    const dateScale = useCallback(scaleTime({
         range: [0, width],
         domain: extent(calculatedTimeSeries, x),
         padding: 0.07
-    })
-    const yScale = scaleLinear({
+    }), [width, calculatedTimeSeries, x])
+    const yScale = useCallback(scaleLinear({
         range: [height, 50],
         domain: [0, max(calculatedTimeSeries, y)],
-    })
+    }), [height, calculatedTimeSeries, y])
     const {
         showTooltip,
         hideTooltip,
@@ -99,7 +105,7 @@ function NationalCurve(props) {
                     </Group>
 
                     <Group>
-                        {calculatedTimeSeries.map((d, i) => {
+                        {useMemo(() => calculatedTimeSeries.map((d, i) => {
                             const pcrHeight = height - yScale(y(d))
                             const atkHeight = height - yScale(d["new_atk_cases"])
                             return (
@@ -123,7 +129,7 @@ function NationalCurve(props) {
                                 </Group>
 
                             );
-                        })}
+                        }), [calculatedTimeSeries, xScale, x, yScale, y, height])}
                     </Group>
 
                     {tooltipData &&
@@ -207,12 +213,11 @@ function NationalCurve(props) {
     )
 }
 
-const Container = (props) => (
+const Container = (props) => 
     <ParentSize>
-        {({ width, height }) => (
+        {useCallback(({ width, height }) => (
             <NationalCurve national_stats={props.national_stats} width={width} height={300} />
-        )}
+        ), [])}
     </ParentSize>
-)
 
 export default Container

--- a/components/infectionCurve.js
+++ b/components/infectionCurve.js
@@ -31,17 +31,17 @@ function NationalCurve(props) {
       },
       [timeSeries]
     )
-    const xScale = useCallback(scaleBand({
+    const xScale = useMemo(() => scaleBand({
         range: [0, width],
         domain: calculatedTimeSeries.map(x),
         padding: 0.07
     }), [width, calculatedTimeSeries, x])
-    const dateScale = useCallback(scaleTime({
+    const dateScale = useMemo(() => scaleTime({
         range: [0, width],
         domain: extent(calculatedTimeSeries, x),
         padding: 0.07
     }), [width, calculatedTimeSeries, x])
-    const yScale = useCallback(scaleLinear({
+    const yScale = useMemo(() => scaleLinear({
         range: [height, 50],
         domain: [0, max(calculatedTimeSeries, y)],
     }), [height, calculatedTimeSeries, y])

--- a/components/vaccine/nationalCurve.tsx
+++ b/components/vaccine/nationalCurve.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useCallback, useMemo } from 'react';
 import { extent, max, bisector, min } from 'd3-array'
 import _, { times } from 'lodash'
 import { Group } from '@visx/group'
@@ -16,28 +16,28 @@ import { AxisBottom } from '@visx/axis'
 
 
 export function NationalCurve(props) {
-    var timeSeries = props.vaccination_timeseries
+    const timeSeries = props.vaccination_timeseries
     const width = props.width
     const height = props.height
-    const x = d => new Date(d['date'])
-    const y = d => d['total_doses']
+    const x = useCallback(d => new Date(d['date']), [])
+    const y = useCallback(d => d['total_doses'], [])
     useEffect(() => {
         props.setUpdateDate(timeSeries[timeSeries.length - 1]['date'])
         props.setTodayData(timeSeries[timeSeries.length - 1])
     }, [timeSeries])
-    const xScale = scaleBand({
+    const xScale = useMemo(() => scaleBand({
         range: [0, width],
         domain: timeSeries.map(x),
         padding: 0.07
-    })
-    const dateScale = scaleTime({
+    }), [width, timeSeries, x])
+    const dateScale = useMemo(() => scaleTime({
         range: [0, width],
         domain: extent(timeSeries, x)
-    })
-    const yScale = scaleLinear({
+    }), [width, timeSeries, x])
+    const yScale = useMemo(() => scaleLinear({
         range: [height, 50],
         domain: [0, Number(max(timeSeries, y))]
-    })
+    }), [height, timeSeries, y])
 
     const {
         showTooltip,
@@ -65,7 +65,7 @@ export function NationalCurve(props) {
                         orientation={['diagonal']}
                     />
                     <Group>
-                        {timeSeries.map((d, i) => {
+                        {useMemo(() => timeSeries.map((d, i) => {
                             const firstDoseHeight = height - yScale(y(d) - d.second_dose)
                             const secondDoseHeight = height - yScale(d.second_dose)
 
@@ -105,7 +105,7 @@ export function NationalCurve(props) {
                                     }
                                 </Group>
                             );
-                        })}
+                        }), [timeSeries, height, xScale, x, yScale, y])}
                     </Group>
                     {tooltipData &&
                         <Bar


### PR DESCRIPTION
Problem: mouse movement tracking on graphs was very bad on graphs with high amount of nodes due to expensive logics
Solution: `useMemo` and `useCallback` everywhere